### PR TITLE
Added .bowerrc file

### DIFF
--- a/templates/_bowerrc
+++ b/templates/_bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory": "/bower_components"
+}


### PR DESCRIPTION
Default path for bower_components is `/app/bower_components`, but gulp bower files tries to read from /bower_components. This change sets  bower_components path to `/bower_components`
