### PR TITLE
Fix for #25 - Swapping out gulp-filter with vinyl-fs for the vendor .css files processing

### DIFF
--- a/templates/gulpfile.js
+++ b/templates/gulpfile.js
@@ -11,6 +11,7 @@ var gulp = require('gulp'),
     lazypipe = require('lazypipe'),
     stylish = require('jshint-stylish'),
     bower = require('./bower'),
+	vinylFs = require('vinyl-fs'),
     isWatching = false;
 
 var htmlminOpts = {
@@ -98,7 +99,7 @@ gulp.task('templates-dist', function () {
 gulp.task('vendors', function () {
   var bowerStream = gulp.src(bowerFiles());
   return es.merge(
-    bowerStream.pipe(g.filter('**/*.css')).pipe(dist('css', 'vendors')),
+    vinylFs.src(['./bower_components/**/*.css', '!./bower_components/**/*.min.css']).pipe(dist('css', 'vendors')),
     bowerStream.pipe(g.filter('**/*.js')).pipe(dist('js', 'vendors'))
   );
 });

--- a/templates/package.json
+++ b/templates/package.json
@@ -37,6 +37,7 @@
     "gulp-csslint": "~0.1.4",
     "event-stream": "^3.1.5",
     "streamqueue": "~0.1.1",
+	"vinyl-fs": "0.3.6",
     "gulp-uglify": "~0.3.0",
     "gulp-htmlmin": "~0.1.2",
     "gulp-ng-html2js": "~0.1.7",


### PR DESCRIPTION
Problem: Too many and/or too big .css files bring gulp-filter to it's knees as when collecting .css files for processing, as I found.
This makes the 'vendors' gulp task to fail silently, stopping the dependent 'dist' task from executing properly either. The latter manifests as the missing index.html file problem in the referenced issue.

Solution: Use vinyl-fs to grab a stream of the input .css files which appears to be competent enough to handle a bigger laundry too.

A much more decent solution would be to investigate and fix the problem of gulp-filter, but that's out of my scope right now unfortunately.
