### PR TITLE
Removing deprecated hgroup element

### DIFF
--- a/templates/src/app/index.html
+++ b/templates/src/app/index.html
@@ -9,10 +9,8 @@
     <!-- endinject -->
   </head>
   <body>
-    <hgroup>
-      <h1><%= modulename %></h1>
-      <h2>Your new AngularJS app is now ready...</h2>
-    </hgroup>
+    <h1><%= modulename %></h1>
+    <h2>Your new AngularJS app is now ready...</h2>
     <ng-view></ng-view>
     <!-- inject:vendor:js -->
     <!-- endinject -->


### PR DESCRIPTION
See http://www.w3.org/wiki/HTML/Elements/hgroup I know that it's silly, just I think it's good idea not to teach newbies deprecated elements.

Thanks
