### PR TITLE
Adding .js and .coffee files to livereload digest so the page will refre...

### DIFF
--- a/templates/gulpfile.js
+++ b/templates/gulpfile.js
@@ -155,10 +155,8 @@ gulp.task('watch', ['statics', 'default'], function () {
   isWatching = true;
   // Initiate livereload server:
   g.livereload.listen();
-  gulp.watch('./src/app/**/*.js', ['jshint']).on('change', function (evt) {
-    if (evt.type !== 'changed') {
-      gulp.start('index');
-    }
+  gulp.watch('./src/app/**/*.{js,coffee}', ['jshint', 'coffee']).on('change', function (evt) {
+    gulp.start('index');
   });
   gulp.watch('./src/app/index.html', ['index']);
   gulp.watch(['./src/app/**/*.html', '!./src/app/index.html'], ['templates']);


### PR DESCRIPTION
I modified the gulpfile.js so that the livereload feature reloads the page when *.js and *.coffee files are saved. 
