### PR TITLE
=BG= compile vendor HTML files too

### DIFF
--- a/templates/gulpfile.js
+++ b/templates/gulpfile.js
@@ -256,7 +256,11 @@ function appFiles () {
  * All AngularJS templates/partials as a stream
  */
 function templateFiles (opt) {
-  return gulp.src(['./src/app/**/*.html', '!./src/app/index.html'], opt)
+  return gulp.src([
+    './src/app/**/*.html',
+    './bower_components/**/*.html',
+    '!./src/app/index.html',
+    ], opt)
     .pipe(opt && opt.min ? g.htmlmin(htmlminOpts) : noop());
 }
 


### PR DESCRIPTION
Useful when the included vendor components contain AngularJs directives, or anything else requiring a HTML template.
