### PR TITLE
=BG= compile vendor SCSS/ LESS files too

### DIFF
--- a/templates/gulpfile.js
+++ b/templates/gulpfile.js
@@ -44,7 +44,9 @@ gulp.task('clean-css', function (done) {
 gulp.task('styles', ['clean-css'], function () {
   return gulp.src([
     './src/app/**/*.<%= styleData.extension %>',
-    '!./src/app/**/_*.<%= styleData.extension %>'
+    '!./src/app/**/_*.<%= styleData.extension %>',
+    './bower_components/**/*.<%= styleData.extension %>',
+    '!./bower_components/**/_*.<%= styleData.extension %>'
   ])
     .pipe(<%= styleData.pipeCommand %>)
     .pipe(gulp.dest('./.tmp/css/'))


### PR DESCRIPTION
Useful when including a bower dependency that package, such as a directive, that includes files that need to go through a CSS pre-processor, such as Sass or Less.
