### PR TITLE
Added Middleware support with HTTP Headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slush-angular",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "A slush generator for AngularJS using the Google Angular App Structure Recommendations",
   "main": "slushfile.js",
   "scripts": {

--- a/slushfile.js
+++ b/slushfile.js
@@ -38,6 +38,7 @@ gulp.task('default', function (done) {
       {name: 'LESS', value: 'less'},
       {name: 'Sass', value: 'sass'}
     ]},
+    {type: 'confirm', name: 'middleware', message: 'Do you want to use middleware for proxy support? If you choose Yes, then the liverelead may not work.', default: false},
     {type: 'confirm', name: 'coffee', message: 'Do you want to use CoffeeScript in your app?', default: false},
     {type: 'confirm', name: 'example', message: 'Do you want to include a Todo List example in your app?', default: true}
   ],

--- a/templates/package.json
+++ b/templates/package.json
@@ -47,6 +47,10 @@
     "karma-script-launcher": "~0.1.0",
     "karma-chrome-launcher": "~0.1.4",
     "karma-firefox-launcher": "~0.1.3",
-    "karma": "~0.12.16"
+    "karma": "~0.12.16"<% if (middleware) { %>,
+    "proxy-middleware": "^0.9.0",
+    "url": "^0.10.2",
+    "gulp-connect": "^2.2.0",
+    "lodash": "^3.0.0"<% } %>
   }
 }

--- a/test/slush-angular_test.js
+++ b/test/slush-angular_test.js
@@ -108,6 +108,35 @@ describe('slush-angular', function() {
       });
     });
 
+    describe('Middleware Example', function () {
+
+      it('should generate template with middleware and LESS', function (done) {
+        mockPrompt({name: 'module', csstype: 'less', example: true, middleware : true});
+
+        gulp.start('default').once('stop', function () {
+          mockGulpDest.assertDestContains([
+            'src/app/app.less',
+            'src/app/styles/_base.less',
+            'src/app/todo/todo.less'
+          ]);
+          done();
+        });
+      });
+
+      it('should generate template with middleware and sass', function (done) {
+        mockPrompt({name: 'module', csstype: 'sass', example: true, middleware : true});
+
+        gulp.start('default').once('stop', function () {
+          mockGulpDest.assertDestContains([
+            'src/app/app.scss',
+            'src/app/styles/_base.scss',
+            'src/app/todo/todo.scss'
+          ]);
+          done();
+        });
+      });
+    });
+
     describe('Todo example', function () {
       it('should not add any todo example files by default', function (done) {
         mockPrompt({name: 'module', example: false});


### PR DESCRIPTION
@joakimbeng This is mainly to address the HTTP access control (CORS) and provide support for service middle-ware to consume external API.

To demo the service please use my public REST API to test. List the Collection `http://loclhost:3000/services/customer` from `http://demo-venkatvp.rhcloud.com/services/customer`

*Note*: the service might be down if inactive for more than 1 hour. So please make a REST call from the browser to bring the service up :)