### PR TITLE
removed app name prefix from templateUrl

### DIFF
--- a/templates/src/app/app.js
+++ b/templates/src/app/app.js
@@ -8,7 +8,7 @@ angular.module('<%= modulename %>', [
   $routeProvider
     .when('/todo', {
       controller: 'TodoCtrl',
-      templateUrl: '/<%= nameDashed %>/todo/todo.html'
+      templateUrl: 'todo/todo.html'
     })
     .otherwise({
       redirectTo: '/todo'


### PR DESCRIPTION
I tried 'slush angular' today with fresh, new installs of node and gulp. I selected SASS and no coffee script. The app works fine except that the todo list is not shown in the browser. I made this very minor change to app.js and it now shows the todo app as I expected when running 'gulp serve'. Hope this helps.
