### PR TITLE
change livereload default port

### DIFF
--- a/templates/gulpfile.js
+++ b/templates/gulpfile.js
@@ -21,6 +21,8 @@ var htmlminOpts = {
   removeRedundantAttributes: true
 };
 
+var LIVE_RELOAD_PORT = 35729;
+
 /**
  * JS Hint
  */
@@ -99,7 +101,7 @@ gulp.task('vendors', function () {
   var files = bowerFiles();
   var vendorJs = fileTypeFilter(files, 'js');
   var vendorCss = fileTypeFilter(files, 'css');
-  var q = new queue({objectMode: true});
+  var q = queue({objectMode: true});
   if (vendorJs.length) {
     q.queue(gulp.src(vendorJs).pipe(dist('js', 'vendors')));
   }
@@ -121,7 +123,7 @@ function index () {
     .pipe(g.inject(gulp.src(bowerFiles(), opt), {ignorePath: 'bower_components', starttag: '<!-- inject:vendor:{{ext}} -->'}))
     .pipe(g.inject(es.merge(appFiles(), cssFiles(opt)), {ignorePath: ['.tmp', 'src/app']}))
     .pipe(gulp.dest('./src/app/'))
-    .pipe(g.embedlr())
+    .pipe(g.embedlr({port: LIVE_RELOAD_PORT}))
     .pipe(gulp.dest('./.tmp/'))
     .pipe(livereload());
 }
@@ -160,7 +162,7 @@ gulp.task('serve', ['watch']);
 gulp.task('watch', ['statics', 'default'], function () {
   isWatching = true;
   // Initiate livereload server:
-  g.livereload.listen();<% if (coffee) { %>
+  g.livereload.listen(LIVE_RELOAD_PORT);<% if (coffee) { %>
   gulp.watch('./src/app/**/*.coffee', ['coffee']);<% } %>
   gulp.watch('./<% if (coffee) { %>.tmp/<% } %>src/app/**/*.js', ['jshint']).on('change', function (evt) {
     if (evt.type !== 'changed') {
@@ -222,7 +224,7 @@ gulp.task('karma-conf', ['templates'], function () {
  * Test files
  */
 function testFiles() {
-  return new queue({objectMode: true})
+  return queue({objectMode: true})
     .queue(gulp.src(fileTypeFilter(bowerFiles(), 'js')))
     .queue(gulp.src('./bower_components/angular-mocks/angular-mocks.js'))
     .queue(appFiles())

--- a/templates/package.json
+++ b/templates/package.json
@@ -20,7 +20,7 @@
     "lazypipe": "~0.2.1",
     "gulp-cached": "^1.0.1",
     "gulp-embedlr": "~0.5.2",
-    "gulp-livereload": "^2.1.0",
+    "gulp-livereload": "^3.0.0",
     "gulp-header": "^1.0.2",
     "gulp-inject": "^1.0.1",
     "gulp-serve": "~0.2.0",


### PR DESCRIPTION
Cloud9 IDE do not support livereload default port 35729, so I need to change it before use `gulp serve`
I think it is a good idea do make this config easy to change

PS: Minor change (new queue -> queue)
